### PR TITLE
Add suport for multi configuration agent reports

### DIFF
--- a/DownloadReleaseArtifactTask/task.json
+++ b/DownloadReleaseArtifactTask/task.json
@@ -37,6 +37,14 @@
          "defaultValue": false,
          "required": true,
          "helpMarkDown": ""
+      },
+      {
+         "name": "publishedInMultiConfigurationAgent",
+         "type": "boolean",
+         "label": "Artifacts were published in Multi-Configuration Agents",
+         "defaultValue": false,
+         "required": true,
+         "helpMarkDown": ""
       }
    ],
    "execution": {


### PR DESCRIPTION
**Related Issues:** 
- https://github.com/huserben/PublishReleaseArtifactsExtension/issues/6

This Pull Request fixes the multi-configuration agent problem. It gives the user the possibility to get the wanted file from each of the multi-configuration agents report folder in order to gather them all.

Fixes the bug refered on [this issue](https://github.com/huserben/PublishReleaseArtifactsExtension/issues/6
) where a folder name with sppecial characters makes the _unzipper_ lib halt. 